### PR TITLE
Fix module link and make repo-relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ Azure lets your create applications composed of various components: web site fro
 This project contains the source code for the **Connect your services together** Learning Path.
 
 ## Modules
+
 Each folder represents a _module_ in the learning path that you can explore.
 
 | Folder | Module |
 |--------|--------|
-| [implement-message-workflows-with-service-bus](https://github.com/MicrosoftDocs/mslearn-connect-services-together/tree/master/%20implement-message-workflows-with-service-bus) | Contains the source code for the [Implement message-based communication workflows with Azure Service Bus](https://docs.microsoft.com/learn/modules/implement-message-workflows-with-service-bus/) module. |
+| [implement-message-workflows-with-service-bus](implement-message-workflows-with-service-bus) | Contains the source code for the [Implement message-based communication workflows with Azure Service Bus](https://docs.microsoft.com/learn/modules/implement-message-workflows-with-service-bus/) module. |
 
 
 # Contributing


### PR DESCRIPTION
Found an errant `%20` in the module URL that was breaking the link. Since it's a relative file to the repo, like the LICENSE* links elsewhere, I made the link relative as well.