### PR TITLE
update the .net core version to 3.1 

### DIFF
--- a/implement-message-workflows-with-service-bus/src/final/performancemessagereceiver/performancemessagereceiver.csproj
+++ b/implement-message-workflows-with-service-bus/src/final/performancemessagereceiver/performancemessagereceiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/final/performancemessagesender/performancemessagesender.csproj
+++ b/implement-message-workflows-with-service-bus/src/final/performancemessagesender/performancemessagesender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/final/privatemessagereceiver/privatemessagereceiver.csproj
+++ b/implement-message-workflows-with-service-bus/src/final/privatemessagereceiver/privatemessagereceiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/final/privatemessagesender/privatemessagesender.csproj
+++ b/implement-message-workflows-with-service-bus/src/final/privatemessagesender/privatemessagesender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/start/performancemessagereceiver/performancemessagereceiver.csproj
+++ b/implement-message-workflows-with-service-bus/src/start/performancemessagereceiver/performancemessagereceiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/start/performancemessagesender/performancemessagesender.csproj
+++ b/implement-message-workflows-with-service-bus/src/start/performancemessagesender/performancemessagesender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/start/privatemessagereceiver/privatemessagereceiver.csproj
+++ b/implement-message-workflows-with-service-bus/src/start/privatemessagereceiver/privatemessagereceiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/start/privatemessagesender/privatemessagesender.csproj
+++ b/implement-message-workflows-with-service-bus/src/start/privatemessagesender/privatemessagesender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
update the .net core version to 3.1 to run this example correctly with the MS learn module: https://docs.microsoft.com/en-us/learn/modules/implement-message-workflows-with-service-bus.

Currently, I get the following error with netcoreapp2.0:

It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '2.0.0' was not found.
  - The following frameworks were found:
      3.1.9 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.

The specified framework can be found at:
  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=2.0.0&arch=x64&rid=cbld.10-x64

