### PR TITLE
changed target framework from netcoreapp3.1 to net6

### DIFF
--- a/implement-message-workflows-with-service-bus/src/final/performancemessagereceiver/performancemessagereceiver.csproj
+++ b/implement-message-workflows-with-service-bus/src/final/performancemessagereceiver/performancemessagereceiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/final/performancemessagesender/performancemessagesender.csproj
+++ b/implement-message-workflows-with-service-bus/src/final/performancemessagesender/performancemessagesender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/final/privatemessagereceiver/privatemessagereceiver.csproj
+++ b/implement-message-workflows-with-service-bus/src/final/privatemessagereceiver/privatemessagereceiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/final/privatemessagesender/privatemessagesender.csproj
+++ b/implement-message-workflows-with-service-bus/src/final/privatemessagesender/privatemessagesender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/start/performancemessagereceiver/performancemessagereceiver.csproj
+++ b/implement-message-workflows-with-service-bus/src/start/performancemessagereceiver/performancemessagereceiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/start/performancemessagesender/performancemessagesender.csproj
+++ b/implement-message-workflows-with-service-bus/src/start/performancemessagesender/performancemessagesender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/start/privatemessagereceiver/privatemessagereceiver.csproj
+++ b/implement-message-workflows-with-service-bus/src/start/privatemessagereceiver/privatemessagereceiver.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/implement-message-workflows-with-service-bus/src/start/privatemessagesender/privatemessagesender.csproj
+++ b/implement-message-workflows-with-service-bus/src/start/privatemessagesender/privatemessagesender.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net6</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
In the Microsoft Learn Exercise
[Send and receive messages by using a queue](
https://docs.microsoft.com/it-it/learn/modules/implement-message-workflows-with-service-bus/5-exercise-write-code-that-uses-service-bus-queues)

when trying to execute code the following error occurs:

```
It was not possible to find any compatible framework version
The framework 'Microsoft.NETCore.App', version '3.1.0' (x64) was not found.
  - The following frameworks were found:
      6.0.5 at [/usr/share/dotnet/shared/Microsoft.NETCore.App]

You can resolve the problem by installing the specified framework and/or SDK.

The specified framework can be found at:
  - https://aka.ms/dotnet-core-applaunch?framework=Microsoft.NETCore.App&framework_version=3.1.0&arch=x64&rid=cbld.10-x64
```

To solve the problem I have to upgrade target framework from netcoreapp3.1 to net6